### PR TITLE
Implement offline task storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,6 +244,35 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
             localStorage.setItem('localAccounts', JSON.stringify(acc));
         }
 
+        // --- Local Storage Fallback for User Data ---
+        function getLocalCollection(name) {
+            const data = localStorage.getItem(`local_${name}`);
+            return data ? JSON.parse(data) : [];
+        }
+
+        function saveLocalCollection(name, items) {
+            localStorage.setItem(`local_${name}`, JSON.stringify(items));
+        }
+
+        function addToLocalCollection(name, item) {
+            const items = getLocalCollection(name);
+            item.id = Date.now().toString();
+            items.push(item);
+            saveLocalCollection(name, items);
+            return item.id;
+        }
+
+        function updateLocalCollection(name, item) {
+            const items = getLocalCollection(name);
+            const idx = items.findIndex(i => i.id === item.id);
+            if (idx !== -1) { items[idx] = item; saveLocalCollection(name, items); }
+        }
+
+        function deleteFromLocalCollection(name, id) {
+            const items = getLocalCollection(name).filter(i => i.id !== id);
+            saveLocalCollection(name, items);
+        }
+
         async function loginUser(username, password, remember) {
             try {
                 let account;
@@ -546,60 +575,93 @@ function initializeOfflineMode() {
         async function addTransactionToFirestore(transaction) {
             const transactionsRef = getUserCollectionRef('transactions');
             if (!transactionsRef) {
-                showToast("Data backend not ready.", 3000);
+                const id = addToLocalCollection('transactions', transaction);
+                transactionsData.push({ ...transaction, id });
+                renderAll();
+                showToast('Transaction saved locally.');
+                resetTransactionForm();
                 return;
             }
             try {
                 const dataToAdd = { ...transaction, createdAt: firebase.firestore.FieldValue.serverTimestamp() };
-                delete dataToAdd.id; // Ensure no local id field is sent if it was accidentally set
-                delete dataToAdd.transactionId; // Ensure this hidden input's name is not part of data
+                delete dataToAdd.id;
+                delete dataToAdd.transactionId;
                 await transactionsRef.add(dataToAdd);
                 showToast('Transaction added!');
                 resetTransactionForm();
             } catch (error) {
                 console.error("Error adding transaction: ", error);
-                showToast(`Error adding transaction: ${error.message}`, 5000); // Show error message
+                const id = addToLocalCollection('transactions', transaction);
+                transactionsData.push({ ...transaction, id });
+                renderAll();
+                showToast('Transaction saved locally.');
             }
         }
 
         async function updateTransactionInFirestore(transaction) {
             const transactionsRef = getUserCollectionRef('transactions');
             if (!transactionsRef || !transaction.id) {
-                showToast("Data backend not ready or missing transaction ID.", 3000);
+                updateLocalCollection('transactions', transaction);
+                const idx = transactionsData.findIndex(t => t.id === transaction.id);
+                if (idx !== -1) transactionsData[idx] = { ...transaction };
+                renderAll();
+                showToast('Transaction updated locally.');
+                resetTransactionForm();
                 return;
             }
             try {
                 const docRef = transactionsRef.doc(transaction.id.toString());
                 const dataToUpdate = { ...transaction };
-                delete dataToUpdate.id; // Don't store the ID within the document itself if it's the doc name
+                delete dataToUpdate.id;
                 delete dataToUpdate.transactionId;
                 await docRef.update(dataToUpdate);
                 showToast('Transaction updated!');
                 resetTransactionForm();
             } catch (error) {
                 console.error("Error updating transaction: ", error);
-                showToast(`Error updating transaction: ${error.message}`, 5000); // Show error message
+                updateLocalCollection('transactions', transaction);
+                const idx = transactionsData.findIndex(t => t.id === transaction.id);
+                if (idx !== -1) transactionsData[idx] = { ...transaction };
+                renderAll();
+                showToast('Transaction updated locally.');
             }
         }
 
         async function deleteTransactionFromFirestore(id) {
             const transactionsRef = getUserCollectionRef('transactions');
-            if (!transactionsRef) { showToast("Data backend not ready.", 3000); return; }
             if (!id) { console.error("Delete failed: Invalid ID provided."); showToast("Error: Invalid transaction ID.", 5000); return; }
+            if (!transactionsRef) {
+                deleteFromLocalCollection('transactions', id);
+                transactionsData = transactionsData.filter(t => t.id !== id);
+                renderAll();
+                showToast('Transaction removed locally.');
+                return;
+            }
             if (confirm('Are you sure you want to delete this transaction?')) {
                 try {
                     await transactionsRef.doc(id.toString()).delete();
                     showToast('Transaction deleted.');
                 } catch (error) {
                     console.error("Error deleting transaction: ", error);
-                    showToast(`Error deleting transaction: ${error.message}`, 5000); // Show error message
+                    deleteFromLocalCollection('transactions', id);
+                    transactionsData = transactionsData.filter(t => t.id !== id);
+                    renderAll();
+                    showToast('Transaction removed locally.');
                 }
             }
         }
 
         async function addReminderToFirestore(reminder) {
             const remindersRef = getUserCollectionRef('reminders');
-            if (!remindersRef) { showToast("Data backend not ready.", 3000); return; }
+            if (!remindersRef) {
+                const id = addToLocalCollection('reminders', reminder);
+                remindersData.push({ ...reminder, id });
+                renderReminders();
+                showToast('Reminder saved locally.');
+                resetReminderForm();
+                toggleReminderForm(false);
+                return;
+            }
             try {
                 const dataToAdd = { ...reminder, createdAt: firebase.firestore.FieldValue.serverTimestamp() };
                 delete dataToAdd.id;
@@ -608,11 +670,20 @@ function initializeOfflineMode() {
                 showToast('Reminder added!');
                 resetReminderForm();
                 toggleReminderForm(false);
-            } catch (error) { console.error("Error adding reminder: ", error); showToast(`Error adding reminder: ${error.message}`, 5000); }
+            } catch (error) { console.error("Error adding reminder: ", error); const id = addToLocalCollection('reminders', reminder); remindersData.push({ ...reminder, id }); renderReminders(); showToast('Reminder saved locally.'); }
         }
         async function updateReminderInFirestore(reminder) {
             const remindersRef = getUserCollectionRef('reminders');
-            if (!remindersRef || !reminder.id) { showToast("Data backend not ready or missing reminder ID.", 3000); return; }
+            if (!remindersRef || !reminder.id) {
+                updateLocalCollection('reminders', reminder);
+                const idx = remindersData.findIndex(r => r.id === reminder.id);
+                if (idx !== -1) remindersData[idx] = { ...reminder };
+                renderReminders();
+                showToast('Reminder updated locally.');
+                resetReminderForm();
+                toggleReminderForm(false);
+                return;
+            }
             try {
                 const docRef = remindersRef.doc(reminder.id.toString());
                 const dataToUpdate = { ...reminder };
@@ -622,17 +693,23 @@ function initializeOfflineMode() {
                 showToast('Reminder updated!');
                 resetReminderForm();
                 toggleReminderForm(false);
-            } catch (error) { console.error("Error updating reminder: ", error); showToast(`Error updating reminder: ${error.message}`, 5000); }
+            } catch (error) { console.error("Error updating reminder: ", error); updateLocalCollection('reminders', reminder); const idx = remindersData.findIndex(r => r.id === reminder.id); if (idx !== -1) remindersData[idx] = { ...reminder }; renderReminders(); showToast('Reminder updated locally.'); }
         }
         async function deleteReminderFromFirestore(id) {
             const remindersRef = getUserCollectionRef('reminders');
-            if (!remindersRef) { showToast("Data backend not ready.", 3000); return; }
             if (!id) { console.error("Delete failed: Invalid ID."); showToast("Error: Invalid reminder ID.", 5000); return; }
+            if (!remindersRef) {
+                deleteFromLocalCollection('reminders', id);
+                remindersData = remindersData.filter(r => r.id !== id);
+                renderReminders();
+                showToast('Reminder removed locally.');
+                return;
+            }
             if (confirm('Are you sure you want to delete this reminder?')) {
                 try {
                     await remindersRef.doc(id.toString()).delete();
                     showToast('Reminder deleted.');
-                } catch (error) { console.error("Error deleting reminder: ", error); showToast(`Error deleting reminder: ${error.message}`, 5000); }
+                } catch (error) { console.error("Error deleting reminder: ", error); deleteFromLocalCollection('reminders', id); remindersData = remindersData.filter(r => r.id !== id); renderReminders(); showToast('Reminder removed locally.'); }
             }
         }
 
@@ -860,13 +937,14 @@ function initializeOfflineMode() {
                             renderAll();
                         }, error => {
                             console.error('Error fetching transactions:', error);
-                            showToast(`Error loading transactions: ${error.message}`, 5000);
-                            transactionsData = [];
+                            transactionsData = getLocalCollection('transactions');
+                            showToast('Using local transactions.', 3000);
                             renderAll();
                         });
                 } else {
-                    console.log('Could not get transactionsRef initially.');
-                    transactionsData = []; renderAll();
+                    console.log('Could not get transactionsRef initially. Using local data.');
+                    transactionsData = getLocalCollection('transactions');
+                    renderAll();
                 }
 
                 const remindersRef = getUserCollectionRef('reminders');
@@ -878,17 +956,19 @@ function initializeOfflineMode() {
                             renderReminders();
                         }, error => {
                             console.error('Error fetching reminders:', error);
-                            showToast(`Error loading reminders: ${error.message}`, 5000);
-                            remindersData = [];
+                            remindersData = getLocalCollection('reminders');
+                            showToast('Using local reminders.', 3000);
                             renderReminders();
                         });
                 } else {
-                    console.log('Could not get remindersRef initially.');
-                    remindersData = []; renderReminders();
+                    console.log('Could not get remindersRef initially. Using local data.');
+                    remindersData = getLocalCollection('reminders');
+                    renderReminders();
                 }
             } else {
-                console.error('Firestore (db) is not initialized or user not logged in. Data listeners not set up.');
-                showToast('Backend connection error. Data cannot be loaded.', 5000);
+                console.error('Firestore (db) is not initialized or user not logged in. Using local data.');
+                transactionsData = getLocalCollection('transactions');
+                remindersData = getLocalCollection('reminders');
                 renderAll();
             }
         }


### PR DESCRIPTION
## Summary
- provide local storage helper functions for offline access
- fall back to local data when Firestore is unavailable
- keep transactions and reminders in memory when saving locally

## Testing
- `git status --short`