### PR TITLE
Add Firebase authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 
     <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.7/firebase-auth-compat.js"></script>
     <style>
         /* Styles remain largely the same - omitted for brevity */
         body { font-family: 'Inter', sans-serif; overscroll-behavior: contain; background-color: #f8fafc; }
@@ -188,6 +189,7 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
         // --- Initialize Firebase ---
         let app;
         let db;
+        let auth;
         try {
             if (!firebase.apps.length) {
                 app = firebase.initializeApp(firebaseConfig);
@@ -195,7 +197,8 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
                 app = firebase.app();
             }
             db = firebase.firestore();
-            console.log("Firebase initialized (App and Firestore only)");
+            auth = firebase.auth();
+            console.log("Firebase initialized (App, Firestore, Auth)");
         } catch (error) {
             console.error("Error initializing Firebase:", error);
             showToast("Error connecting to backend.", 5000);
@@ -223,17 +226,17 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
             bottomNav.classList.remove('hidden');
         }
 
-        function saveRemember(username) {
+        function saveRemember(userId) {
             const expiry = new Date();
             expiry.setHours(23,59,59,999);
-            localStorage.setItem('rememberUser', JSON.stringify({ username, expiry: expiry.getTime() }));
+            localStorage.setItem('rememberUser', JSON.stringify({ userId, expiry: expiry.getTime() }));
         }
         function loadRemember() {
             const item = localStorage.getItem('rememberUser');
             if (!item) return null;
             const data = JSON.parse(item);
             if (Date.now() > data.expiry) { localStorage.removeItem('rememberUser'); return null; }
-            return data.username;
+            return data.userId;
         }
 
         function getStoredAccounts() {
@@ -275,28 +278,17 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
 
         async function loginUser(username, password, remember) {
             try {
-                let account;
-                if (db) {
-                    try {
-                        const doc = await db.collection('userAccounts').doc(username).get();
-                        if (!doc.exists) { showToast('User not found'); return; }
-                        if (doc.data().password !== password) { showToast('Incorrect password'); return; }
-                        account = doc.data();
-                    } catch (e) {
-                        console.warn('Firestore login failed, falling back to local storage', e);
-                        const accounts = getStoredAccounts();
-                        if (!accounts[username]) { showToast('User not found'); return; }
-                        if (accounts[username].password !== password) { showToast('Incorrect password'); return; }
-                        account = accounts[username];
-                    }
+                if (auth) {
+                    const email = `${username}@sng.app`;
+                    const credential = await auth.signInWithEmailAndPassword(email, password);
+                    currentUserId = credential.user.uid;
                 } else {
                     const accounts = getStoredAccounts();
                     if (!accounts[username]) { showToast('User not found'); return; }
                     if (accounts[username].password !== password) { showToast('Incorrect password'); return; }
-                    account = accounts[username];
+                    currentUserId = username;
                 }
-                currentUserId = username;
-                if (remember) saveRemember(username); else localStorage.removeItem('rememberUser');
+                if (remember) saveRemember(currentUserId); else localStorage.removeItem('rememberUser');
                 showApp();
                 setupFirestoreListeners();
             } catch (e) { console.error(e); showToast('Login error'); }
@@ -312,14 +304,20 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
                 return true;
             };
             try {
-                if (db) {
-                    await db.collection('userAccounts').doc(username).set({ nickname: nick, username, password });
+                if (auth) {
+                    const email = `${username}@sng.app`;
+                    const cred = await auth.createUserWithEmailAndPassword(email, password);
+                    currentUserId = cred.user.uid;
+                    if (db) {
+                        await db.collection('users').doc(currentUserId).set({ nickname: nick, username });
+                    }
                 } else {
                     if (!saveLocalAccount()) return;
                 }
                 showToast('Account created. Please log in.');
                 registerForm.reset();
                 showAuthForms(true);
+                if (auth) await auth.signOut();
             } catch (e) {
                 console.error(e);
                 if (saveLocalAccount()) {
@@ -335,6 +333,7 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
         function logoutUser() {
             if (unsubscribeTransactions) unsubscribeTransactions();
             if (unsubscribeReminders) unsubscribeReminders();
+            if (auth) auth.signOut();
             currentUserId = null;
             localStorage.removeItem('rememberUser');
             showAuth();
@@ -977,13 +976,25 @@ function initializeOfflineMode() {
             navigateTo(defaultSection);
             setupChatbot();
             dateInput.valueAsDate = new Date();
-            const remembered = loadRemember();
-            if (remembered) {
-                currentUserId = remembered;
-                showApp();
-                setupFirestoreListeners();
+            if (auth) {
+                auth.onAuthStateChanged(user => {
+                    if (user) {
+                        currentUserId = user.uid;
+                        showApp();
+                        setupFirestoreListeners();
+                    } else {
+                        showAuth();
+                    }
+                });
             } else {
-                showAuth();
+                const remembered = loadRemember();
+                if (remembered) {
+                    currentUserId = remembered;
+                    showApp();
+                    setupFirestoreListeners();
+                } else {
+                    showAuth();
+                }
             }
         });
 


### PR DESCRIPTION
## Summary
- add Firebase Auth to script imports
- initialize `auth` with Firebase
- update login and account creation to use Firebase Authentication and store profile info in Firestore
- sign users out via Auth and check auth state on load
- keep fallback local storage when auth is unavailable

## Testing
- `git status --short`