### PR TITLE
Auto login after account creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,9 +270,11 @@ if (window.matchMedia('(display-mode: standalone)').matches) {
             try {
                 const cred = await auth.createUserWithEmailAndPassword(email, password);
                 await db.collection('users').doc(cred.user.uid).set({ nickname: nick, email });
-                showToast('Account created. Please log in.');
+                currentUserId = cred.user.uid;
+                showApp();
+                setupFirestoreListeners();
+                showToast('Welcome!');
                 registerForm.reset();
-                showAuthForms(true);
             } catch (e) {
                 console.error(e);
                 showToast('Account creation failed');


### PR DESCRIPTION
## Summary
- auto-login and initialise Firestore listeners after creating an account
- show welcome toast instead of requesting a login

## Testing
- `grep -n "Please log in" -r .`
