### PR TITLE
Fix icon references

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,14 @@
 <meta name="apple-mobile-web-app-title" content="SNG Finance">
 
 <!-- Add icon links for Apple devices -->
-<link rel="apple-touch-icon" href="/icons/icon-192x192.png">
+<link rel="apple-touch-icon" href="/icon-192x192.png">
 
 <!-- Essential for PWAs -->
-<link rel="shortcut icon" href="/icons/icon-192x192.png">
+<link rel="shortcut icon" href="/icon-192x192.png">
 
 <!-- Ensure the correct path to your manifest file -->
 <link rel="manifest" href="/manifest.json">
     <title>SNG Finance - Boston Student Finances</title>
-    <link rel="manifest" href="manifest.json">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,13 +8,13 @@
   "theme_color": "#4f46e5",
   "icons": [
     {
-      "src": "/icons/icon-192x192.png?v=1.1",
+      "src": "/icon-192x192.png?v=1.1",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-512x512.png?v=1.1",
+      "src": "/icon-512x512.png?v=1.1",
       "type": "image/png",
       "sizes": "512x512",
       "purpose": "any maskable"

--- a/sw.js
+++ b/sw.js
@@ -7,8 +7,8 @@ const urlsToCache = [
   '/index.html',
   '/manifest.json',
   // Fix icon paths to match actual paths in your manifest
-  '/icons/icon-192x192.png',
-  '/icons/icon-512x512.png',
+  '/icon-192x192.png',
+  '/icon-512x512.png',
   // Cache external resources
   'https://cdn.tailwindcss.com',
   'https://cdn.jsdelivr.net/npm/chart.js',
@@ -273,7 +273,7 @@ self.addEventListener('fetch', event => {
             
             // For image requests, return a cached placeholder
             if (event.request.destination === 'image') {
-              return caches.match('/icons/icon-192x192.png')
+            return caches.match('/icon-192x192.png')
                 .then(placeholderImage => {
                   if (placeholderImage) return placeholderImage;
                   // If no placeholder, just propagate the error


### PR DESCRIPTION
## Summary
- fix icon paths in `manifest.json`
- update HTML with new icon paths and remove duplicate manifest link
- update service worker to cache new icon locations

## Testing
- `node --check sw.js`
- `node --check renameFirestoreDocument.js`
